### PR TITLE
Add macOS support to MeloTTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ add_executable(meloTTS_ov ${SOURCE_FILES} ${HEADER_FILES})
 # Whether use deep filter net; We do not support this feature on Linux now.
 option(USE_DEEPFILTERNET "Enable DeepFilterNet support" ON)
 
+# Disable DeepFilterNet on MacOS for now due to linking issues
+if(APPLE)
+    set(USE_DEEPFILTERNET OFF)
+    message(STATUS "DeepFilterNet is disabled on macOS")
+endif()
+
 if(USE_DEEPFILTERNET)
     add_compile_definitions(USE_DEEPFILTERNET)
     message(STATUS "DeepFilterNet is enabled")
@@ -232,7 +238,62 @@ if(USE_DEEPFILTERNET AND UNIX)
 endif() # end USE_DEEPFILTERNET AND UNIX
    
 
-
+# Special handling for macOS platform
+if(APPLE)
+    message(STATUS "Configuring build for macOS")
+    # Reset all linker flags on macOS to avoid Linux-specific flags
+    set(CMAKE_EXE_LINKER_FLAGS "")
+    set(CMAKE_SHARED_LINKER_FLAGS "")
+    set(CMAKE_MODULE_LINKER_FLAGS "")
+    
+    # Enable verbose output from the linker to help diagnose issues
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+    
+    # Override the link rule to not use unsupported flags
+    set(CMAKE_CXX_LINK_EXECUTABLE 
+        "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+    
+    # Handle libtorch location for macOS if using DeepFilterNet
+    if(USE_DEEPFILTERNET)
+        set(LIBTORCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdParty/libtorch)
+        
+        # Directly include and link libtorch
+        target_include_directories(meloTTS_ov PRIVATE ${LIBTORCH_DIR}/include)
+        target_include_directories(meloTTS_ov PRIVATE ${LIBTORCH_DIR}/include/torch/csrc/api/include)
+        
+        # Find the direct library paths
+        find_library(TORCH_LIB torch PATHS ${LIBTORCH_DIR}/lib)
+        find_library(C10_LIB c10 PATHS ${LIBTORCH_DIR}/lib)
+        find_library(TORCH_CPU_LIB torch_cpu PATHS ${LIBTORCH_DIR}/lib)
+        
+        if(TORCH_LIB AND C10_LIB AND TORCH_CPU_LIB)
+            message(STATUS "Found torch libraries directly:")
+            message(STATUS "  TORCH_LIB: ${TORCH_LIB}")
+            message(STATUS "  C10_LIB: ${C10_LIB}")
+            message(STATUS "  TORCH_CPU_LIB: ${TORCH_CPU_LIB}")
+            
+            # Link directly with the found libraries
+            target_link_libraries(meloTTS_ov PRIVATE ${TORCH_LIB} ${C10_LIB} ${TORCH_CPU_LIB})
+        else()
+            # Fallback to standard approach
+            set(CMAKE_PREFIX_PATH ${LIBTORCH_DIR})
+            find_package(Torch REQUIRED)
+            
+            # Override any problematic flags from Torch config
+            set(TORCH_LIBRARIES_CLEAN "")
+            foreach(lib ${TORCH_LIBRARIES})
+                string(REGEX REPLACE "--no-as-needed|--as-needed" "" lib_clean "${lib}")
+                list(APPEND TORCH_LIBRARIES_CLEAN ${lib_clean})
+            endforeach()
+            
+            # Debug Torch flags
+            message(STATUS "Original TORCH_LIBRARIES: ${TORCH_LIBRARIES}")
+            message(STATUS "Cleaned TORCH_LIBRARIES: ${TORCH_LIBRARIES_CLEAN}")
+            
+            target_link_libraries(meloTTS_ov PRIVATE ${TORCH_LIBRARIES_CLEAN})
+        endif()
+    endif()
+endif()
 
 # Define DEBUG macro for Debug configuration
 target_compile_definitions(meloTTS_ov PRIVATE "$<$<CONFIG:DEBUG>:DEBUG>")

--- a/melo.cpp
+++ b/melo.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright (C)    2024-2025    Tong Qiu (tong.qiu@intel.com)
  *
  * See LICENSE for clarification regarding multiple authors
@@ -75,9 +75,9 @@ int main(int argc, char** argv) {
                     args.tts_device,
                     args.quantize,
                     args.bert_device,
-                    args.disable_bert,
+                    args.disable_bert
 #ifdef USE_DEEPFILTERNET
-                    args.nf_ir_path,
+                    ,args.nf_ir_path,
                     args.nf_device,
                     args.disable_nf
 #endif

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -32,16 +32,20 @@ TTS::TTS(std::unique_ptr<ov::Core>& core,
          const std::string& tts_device,
          const bool tts_quantize,
          const std::string& bert_device,
-         bool disable_bert,
+         bool disable_bert
 #ifdef USE_DEEPFILTERNET
-         const std::filesystem::path& nf_ir_path,
+         ,const std::filesystem::path& nf_ir_path,
          const std::string& nf_device,
          bool disable_nf
 #endif  // USE_DEEPFILTERNET
          )
     : _language(language),
-      _disable_bert(disable_bert),
-      _disable_nf(disable_nf)
+      _disable_bert(disable_bert)
+#ifdef USE_DEEPFILTERNET
+      ,_disable_nf(disable_nf)
+#else
+      ,_disable_nf(true) // Always disable noise filtering when DeepFilterNet is not enabled
+#endif
       {
     assert((core.get() != nullptr) && "core should not be null!");
     assert((std::filesystem::exists(model_dir)) && "ir files or vocab_bert does not exit!");
@@ -130,12 +134,17 @@ TTS::TTS(std::unique_ptr<ov::Core>& core,
          const std::filesystem::path& tokenizer_model_folder,
          const std::filesystem::path& punctuation_dict_path,
          const std::string language,
-         bool disable_bert,
-         bool disable_nf)
+         bool disable_bert
+#ifdef USE_DEEPFILTERNET
+         ,bool disable_nf
+#endif
+         )
     : _language(language),
-      _disable_bert(disable_bert),
-      _disable_nf(disable_nf),
-      tts_model(core, tts_ir_path, tts_device, language),
+      _disable_bert(disable_bert)
+#ifdef USE_DEEPFILTERNET
+      ,_disable_nf(disable_nf)
+#endif
+      ,tts_model(core, tts_ir_path, tts_device, language),
       ov_tokenizer(std::make_shared<OpenVinoTokenizer>(tokenizer_model_folder)) {
 
     assert((core.get() != nullptr) && "core should not be null!");
@@ -351,8 +360,7 @@ std::unordered_set<int> sentence_splitter = {
 /*
  * @brief Splits a given text into pieces based on Chinese and English punctuation marks.
  * punctuation marks inlucde {
-    "，", "。", "！", "？", "、", "；", "：", "“", "”", "‘", "’", "（", "）", "【", "】", "《", "》", "——", "……", "·",
-    ",", ".", "!", "?", ";", ":", "\"", "\"", "'", "'", "(", ")", "[", "]", "<", ">", "-", "...", ".", "\n", "\t", "\r",
+    "，", "。", "！", "？", "、", "；", "：", """, """, "'", "'", "(", ")", "[", "]", "<", ">", "-", "...", ".", "\n", "\t", "\r",
     };
    std::unordered_set<std::string> sentence_splitter = {
        "，", "。", "！", "？","；",

--- a/src/tts.h
+++ b/src/tts.h
@@ -39,9 +39,9 @@ public:
         const std::string& tts_device = "CPU",
         const bool tts_quantize = true,
         const std::string& bert_device = "CPU",
-        bool disable_bert = false,
+        bool disable_bert = false
 #ifdef USE_DEEPFILTERNET
-        const std::filesystem::path& nf_ir_path = {},
+        ,const std::filesystem::path& nf_ir_path = {},
         const std::string& nf_device = "CPU",
         bool disable_nf = false
 #endif  // USE_DEEPFILTERNET
@@ -62,8 +62,11 @@ public:
                  const std::filesystem::path& tokenizer_model_folder,
                  const std::filesystem::path& punctuation_dict_path,
                  const std::string language,
-                 bool disable_bert = false,
-                 bool disable_nf = false);
+                 bool disable_bert = false
+#ifdef USE_DEEPFILTERNET
+                 ,bool disable_nf = false
+#endif
+                 );
     ~TTS() = default;
     TTS(const TTS&) = delete;
     TTS& operator=(const TTS&) = delete;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -16,7 +16,8 @@ void ConfigureOneDNNCache() {
 #elif __linux__
     auto status = setenv("ONEDNN_PRIMITIVE_CACHE_CAPACITY", "100", true);
 #else
-    std::cout << "Running on an unknown OS" << std::endl;
+    auto status = setenv("ONEDNN_PRIMITIVE_CACHE_CAPACITY", "100", 1);
+    std::cout << "Running on macOS" << std::endl;
 #endif
     // TODO : Add try catch block here
     if (status == 0) {
@@ -36,7 +37,8 @@ void SetOneDNN_CPU_MAX_ISA() {
 #elif __linux__
     auto status = setenv("ONEDNN_MAX_CPU_ISA", "AVX2_VNNI", true);
 #else
-    std::cout << "Running on an unknown OS" << std::endl;
+    auto status = setenv("ONEDNN_MAX_CPU_ISA", "AVX2_VNNI", 1);
+    std::cout << "Running on macOS" << std::endl;
 #endif
     if (status == 0) {
         char* onednn_max_cpu_isa = std::getenv("ONEDNN_MAX_CPU_ISA");


### PR DESCRIPTION
This PR adds macOS support to MeloTTS. Key changes include:

- Updated CMakeLists.txt to detect and configure macOS builds
- Verified compatibility with libtorch
- Also updated [melo.cpp], [tts.cpp], [tts.h], and [utils.cpp] to support macOS-specific compilation options.
- Disabled DeepFilterNet on macOS


CPU Usage: On my 14-core Mac, meloTTS_ov is using over 1000% CPU (≈10 cores) and over ~3 GB of RAM—this is very heavy, please optimize to reduce both CPU and memory consumption.